### PR TITLE
chore: get rid of mediaCss function

### DIFF
--- a/src/Footer/Footer.tsx
+++ b/src/Footer/Footer.tsx
@@ -1,6 +1,5 @@
 import React from '@portal/react';
 import styled from '@portal/styled-components';
-import { mediaCSS } from '@redocly/reference-docs';
 import { FooterColumns } from '@theme/Footer/FooterColumns';
 import { FooterCopyright } from '@theme/Footer/FooterCopyright';
 
@@ -22,9 +21,9 @@ const FooterContainer = styled.footer`
   flex-shrink: 0;
   background-color: var(--footer-color-background);
   color: var(--footer-color-text);
+  font-family: var(--font-family-primary);
   a,
   a:hover {
     color: var(--footer-color-text);
   }
-  ${mediaCSS({ fontFamily: 'var(--font-family-primary)' })};
 `;

--- a/src/Footer/FooterColumn.tsx
+++ b/src/Footer/FooterColumn.tsx
@@ -1,6 +1,5 @@
 import React from '@portal/react';
 import styled from '@portal/styled-components';
-import { mediaCSS } from '@redocly/reference-docs';
 import { Link } from '@portal/Link';
 
 export default function FooterColumn({ column }) {
@@ -27,7 +26,7 @@ const FooterColumnTitle = styled.p`
   font-weight: var(--font-weight-regular);
   font-size: 24px;
   margin-bottom: 1.5em;
-  ${mediaCSS({ fontFamily: 'var(--font-family-h)' })};
+  font-family: var(--font-family-h);
 `;
 
 const FooterSeparator = styled.div`
@@ -35,7 +34,7 @@ const FooterSeparator = styled.div`
   margin: 10px 0 5px 0;
   font-size: 0.75em;
   text-transform: uppercase;
-  ${mediaCSS({ fontFamily: 'var(--font-family-h)' })};
+  font-family: var(--font-family-h);
 `;
 
 const FooterColumnContainer = styled.div`

--- a/src/ui/Background.tsx
+++ b/src/ui/Background.tsx
@@ -1,11 +1,10 @@
 import { Flex } from '@theme/ui/Flex';
 import styled from '@portal/styled-components';
-import { mediaCSS } from '@redocly/reference-docs';
 
 export const Background = styled(Flex)`
   background: var(--navbar-color-background);
   color: var(--color-primary-contrast);
-  ${mediaCSS({ fontFamily: 'var(--h-font-family)' })};
+  font-family: var(--h-font-family);
 
   a:not([role='button']),
   a:not([role='button']):hover {

--- a/src/ui/Tiles/TileHeader.ts
+++ b/src/ui/Tiles/TileHeader.ts
@@ -1,11 +1,10 @@
 import styled from '@portal/styled-components';
-import { mediaCSS } from '@redocly/reference-docs';
 
 export const TileHeader = styled.h3<{ color?: string }>`
   font-weight: var(--font-weight-bold);
   line-height: 1.25;
   color: ${props => props.color || 'var(--color-primary-main)'};
-  ${mediaCSS({ fontFamily: 'var(--h-font-family)' })};
+  font-family: var(--h-font-family);
   && {
     margin: 0 0 0.5em;
   }

--- a/src/ui/Tiles/TileText.tsx
+++ b/src/ui/Tiles/TileText.tsx
@@ -1,5 +1,4 @@
 import styled from '@portal/styled-components';
-import { mediaCSS } from '@redocly/reference-docs';
 
 export const TileText = styled.span<{ color?: string }>`
   display: inline-block;
@@ -7,5 +6,5 @@ export const TileText = styled.span<{ color?: string }>`
   overflow: hidden;
   color: ${props => props.color || 'var(--color-text-main)'};
   line-height: 1.25;
-  ${mediaCSS({ fontFamily: 'var(--font-family-primary)' })};
+  font-family: var(--font-family-primary);
 `;

--- a/src/ui/Typography.tsx
+++ b/src/ui/Typography.tsx
@@ -1,4 +1,3 @@
-import { mediaCSS } from '@redocly/reference-docs';
 import styled, { css } from '@portal/styled-components';
 import { color, typography as typographySystem, ColorProps, TypographyProps } from '@portal/styled-system';
 
@@ -59,14 +58,12 @@ export const typographyTokens = {
 export function typography(theme) {
   if (!theme) return '';
   return css`
-    ${mediaCSS({
-      fontSize: theme.fontSize || '',
-      fontWeight: theme.fontWeight || '',
-      fontFamily: theme.fontFamily || '',
-      lineHeight: theme.lineHeight || '',
-      color: theme.color || '',
-      textTransform: theme.transform || '',
-    })}
+    font-size: ${theme.fontSize || ''};
+    font-weight: ${theme.fontWeight || ''};
+    font-family: ${theme.fontFamily || ''};
+    line-height: ${theme.lineHeight || ''};
+    color: ${theme.color || ''};
+    text-transform: ${theme.transform || ''};
   `;
 }
 
@@ -120,7 +117,7 @@ export const SectionHeader = styled.h2`
   text-align: center;
   margin: 2.65em 0;
   padding: 0px 20px;
-  ${mediaCSS({ fontFamily: 'var(--font-family-h)' })};
+  font-family: var(--font-family-h);
 `;
 
 export const Typography = styled.p<


### PR DESCRIPTION
## What/Why/How?

Usage of `mediaCss` function was removed in reference-docs by [this PR](https://github.com/Redocly/reference-docs/pull/701).
We're removing it here as well

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
